### PR TITLE
Add ability and default to running cargo with --all

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ name = "integration"
 path = "test/test.rs"
 
 [features]
-default = ["prepush-hook", "run-cargo-test"]
+default = ["prepush-hook", "run-cargo-test", "run-for-all"]
 prepush-hook = []
 precommit-hook = []
 postmerge-hook = []
@@ -33,6 +33,7 @@ run-cargo-test = []
 run-cargo-check = []
 run-cargo-clippy = []
 run-cargo-fmt = []
+run-for-all = []
 user-hooks = []
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -102,9 +102,25 @@ fn hook_already_exists(hook: &Path) -> bool {
 }
 
 fn write_script<W: io::Write>(w: &mut W) -> Result<()> {
-    macro_rules! cmd {
+    macro_rules! raw_cmd {
         ($c:expr) => {
             concat!("\necho '+", $c, "'\n", $c)
+        }
+    }
+    macro_rules! cmd {
+        ($c:expr) => {
+            if cfg!(feature = "run-for-all") {
+                raw_cmd!(concat!($c, " --all"))
+            } else {
+                raw_cmd!($c)
+            }
+        };
+        ($c:expr, $subflags:expr) => {
+            if cfg!(feature = "run-for-all") {
+                raw_cmd!(concat!($c, " --all -- ", $subflags))
+            } else {
+                raw_cmd!(concat!($c, " -- ", $subflags))
+            }
         };
     }
 
@@ -117,10 +133,10 @@ fn write_script<W: io::Write>(w: &mut W) -> Result<()> {
             s += cmd!("cargo check");
         }
         if cfg!(feature = "run-cargo-clippy") {
-            s += cmd!("cargo clippy -- -D warnings");
+            s += cmd!("cargo clippy", "-D warnings");
         }
         if cfg!(feature = "run-cargo-fmt") {
-            s += cmd!("cargo fmt -- --check");
+            s += cmd!("cargo fmt",  "--check");
         }
         s
     };


### PR DESCRIPTION
This is useful for projects containing cargo workspaces.  I added a feature for those who want to opt out of this behavior (e.g. if a repo contains a module that intentionally fails to compile for testing purposes)