### PR TITLE
Create .git/hooks dir, of it doesn't exists

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -186,6 +186,12 @@ fn install_hook(hook: &str) -> Result<()> {
     let hook_path = {
         let mut p = resolve_gitdir()?;
         p.push("hooks");
+
+        // Check if .git/hooks exists and create it if not
+        if !p.exists() {
+            fs::create_dir(p.as_path())?;
+        }
+
         p.push(hook);
         p
     };


### PR DESCRIPTION
This pull request fixes #25. Some git clients don't create the `hooks` folder inside the `.git` dir. With this changes, cargo-husky creates this folder while installing the hooks.