### PR TITLE
Add feature `run-cargo-fmt-write`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ run-cargo-test = []
 run-cargo-check = []
 run-cargo-clippy = []
 run-cargo-fmt = []
+run-cargo-fmt-write = []
 run-for-all = []
 user-hooks = []
 

--- a/README.md
+++ b/README.md
@@ -75,17 +75,18 @@ This configuration generates `.git/hooks/pre-commit` script which runs `cargo te
 
 All features are follows:
 
-| Feature            | Description                                                         | Default  |
-|--------------------|---------------------------------------------------------------------|----------|
-| `run-for-all`      | Add `--all` option to command to run it for all crates in workspace | Enabled  |
-| `prepush-hook`     | Generate `pre-push` hook script                                     | Enabled  |
-| `precommit-hook`   | Generate `pre-commit` hook script                                   | Disabled |
-| `postmerge-hook`   | Generate `post-merge` hook script                                   | Disabled |
-| `run-cargo-test`   | Run `cargo test` in hook scripts                                    | Enabled  |
-| `run-cargo-check`  | Run `cargo check` in hook scripts                                   | Disabled |
-| `run-cargo-clippy` | Run `cargo clippy -- -D warnings` in hook scripts                   | Disabled |
-| `run-cargo-fmt`    | Run `cargo fmt -- --check` in hook scripts                          | Disabled |
-| `user-hooks`       | See below section                                                   | Disabled |
+| Feature               | Description                                                         | Default  |
+|-----------------------|---------------------------------------------------------------------|----------|
+| `run-for-all`         | Add `--all` option to command to run it for all crates in workspace | Enabled  |
+| `prepush-hook`        | Generate `pre-push` hook script                                     | Enabled  |
+| `precommit-hook`      | Generate `pre-commit` hook script                                   | Disabled |
+| `postmerge-hook`      | Generate `post-merge` hook script                                   | Disabled |
+| `run-cargo-test`      | Run `cargo test` in hook scripts                                    | Enabled  |
+| `run-cargo-check`     | Run `cargo check` in hook scripts                                   | Disabled |
+| `run-cargo-clippy`    | Run `cargo clippy -- -D warnings` in hook scripts                   | Disabled |
+| `run-cargo-fmt`       | Run `cargo fmt -- --check` in hook scripts                          | Disabled |
+| `run-cargo-fmt-write` | Run `cargo fmt` in hook scripts – formatting code if needed         | Disabled |
+| `user-hooks`          | See below section                                                   | Disabled |
 
 
 ## User Hooks

--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,7 @@ impl fmt::Debug for Error {
             Error::OutDir(env::VarError::NotUnicode(msg)) => msg.to_string_lossy().to_string(),
             Error::InvalidUserHooksDir(path) => {
                 format!("User hooks directory is not found or no executable file is found in '{:?}'. Did you forget to make a hook script executable?", path)
-	        }
+            }
             Error::EmptyUserHook(path) => format!("User hook script is empty: {:?}", path),
         };
         write!(f, "{}", msg)
@@ -138,7 +138,9 @@ fn write_script<W: io::Write>(w: &mut W) -> Result<()> {
         if cfg!(feature = "run-cargo-clippy") {
             s += cmd!("cargo clippy", "-D warnings");
         }
-        if cfg!(feature = "run-cargo-fmt") {
+        if cfg!(feature = "run-cargo-fmt-write") {
+            s += cmd!("cargo fmt");
+        } else if cfg!(feature = "run-cargo-fmt") {
             s += cmd!("cargo fmt", "--check");
         }
         s


### PR DESCRIPTION
This is just like `run-cargo-fmt`, except it formats code without user intervention.
I find this to be great optional behavior – as a dev it's a mindless task to run `cargo fmt` myself, when this could very well happen in the background, saving me time safely. This is how I have `prettier` set up with the original Node `husky` and I'd love to have the same convenience with `cargo fmt`.