### PR TITLE
Reordered commands in increasing execution times

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -129,8 +129,8 @@ fn write_script<W: io::Write>(w: &mut W) -> Result<()> {
 
     let script = {
         let mut s = String::new();
-        if cfg!(feature = "run-cargo-test") {
-            s += cmd!("cargo test");
+        if cfg!(feature = "run-cargo-fmt") {
+            s += cmd!("cargo fmt", "--check");
         }
         if cfg!(feature = "run-cargo-check") {
             s += cmd!("cargo check");
@@ -138,8 +138,8 @@ fn write_script<W: io::Write>(w: &mut W) -> Result<()> {
         if cfg!(feature = "run-cargo-clippy") {
             s += cmd!("cargo clippy", "-D warnings");
         }
-        if cfg!(feature = "run-cargo-fmt") {
-            s += cmd!("cargo fmt", "--check");
+        if cfg!(feature = "run-cargo-test") {
+            s += cmd!("cargo test");
         }
         s
     };


### PR DESCRIPTION
This patch rearranges the order of the commands in the hook scripts created by cargo-husky to match their expected execution time. For example, "cargo fmt" should be significantly faster to execute than "cargo clippy" and "cargo test".

This addresses annoying situations like linting checks failing only after the entire test suite has run.
