### PR TITLE
Set license=MIT to allow automated tools to process this crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/rhysd/cargo-husky#readme"
 readme = "README.md"
 keywords = ["git", "hook", "cargo"]
 categories = ["development-tools"]
-license-file = "LICENSE.txt"
+license = "MIT"
 build = "build.rs"
 include = ["build.rs", "LICENSE.txt", "Cargo.toml", "src/**/*.rs"]
 


### PR DESCRIPTION
I was not able to propose this tool for the [rust-analyzer](https://github.com/rust-lang/rust-analyzer) because it uses an automated test to verify that all dependencies use compatible open source licenses.

[Cargo.toml documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) recommends license-file to be used only for non-standard licenses.